### PR TITLE
fix: Vue 2.7 using incorrect directive API

### DIFF
--- a/src/directives/keyboard-trap/index.js
+++ b/src/directives/keyboard-trap/index.js
@@ -2,7 +2,7 @@ import * as Vue from 'vue';
 
 import directiveFactory from './directive';
 
-const { markRaw } = Vue;
+const { markRaw, version } = Vue;
 
 const directivePlugin = {
   install(app, options) {
@@ -14,7 +14,11 @@ const directivePlugin = {
 
 export default directivePlugin;
 
-const VueKeyboardTrapDirectiveFactory = (options) => directiveFactory(options, markRaw);
+function isVue2() {
+  return version?.startsWith('2.');
+}
+
+const VueKeyboardTrapDirectiveFactory = (options) => directiveFactory(options, (isVue2()) ? undefined : markRaw);
 
 export {
   directivePlugin as VueKeyboardTrapDirectivePlugin,

--- a/src/directives/keyboard-trap/index.js
+++ b/src/directives/keyboard-trap/index.js
@@ -3,10 +3,11 @@ import * as Vue from 'vue';
 import directiveFactory from './directive';
 
 const { markRaw, version } = Vue;
+const vue3MarkRaw = version.indexOf('2.') === 0 ? undefined : markRaw;
 
 const directivePlugin = {
   install(app, options) {
-    const { name, directive } = directiveFactory(options, markRaw);
+    const { name, directive } = directiveFactory(options, vue3MarkRaw);
 
     app.directive(name, directive);
   },
@@ -14,11 +15,7 @@ const directivePlugin = {
 
 export default directivePlugin;
 
-function isVue2() {
-  return version?.startsWith('2.');
-}
-
-const VueKeyboardTrapDirectiveFactory = (options) => directiveFactory(options, (isVue2()) ? undefined : markRaw);
+const VueKeyboardTrapDirectiveFactory = (options) => directiveFactory(options, vue3MarkRaw);
 
 export {
   directivePlugin as VueKeyboardTrapDirectivePlugin,


### PR DESCRIPTION
This is a quick fix for Vue 2.7, which exports `markRaw` but doesn't support [Vue 3's directive structure](https://v3-migration.vuejs.org/breaking-changes/custom-directives.html#custom-directives) (e.g. `bind` -> `beforeMount`).

For example,
https://codepen.io/nicholas-ramsey/pen/ExLELLb?editors=0010 - Vue 2.7 - Doesn't work
https://codepen.io/nicholas-ramsey/pen/qBYoYyK?editors=0010 - Vue 2.6 - Works

Thanks for your work on this awesome library. 👍 